### PR TITLE
feat: debloat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,7 @@
   },
   "dependencies": {
     "@mediagoom/opflow": "0.0.31",
-    "@mediagoom/chunk-upload": "0.0.19",
     "debug": "^4.1.0",
-    "express": "^4.16.4",
     "parse-spawn-args": "^1.0.2"
   },
   "engines": {


### PR DESCRIPTION
Hi,

Thanks for developing this good project, which provides high-coverage tests.

I'm doing dynamic analysis on npm packages, and your project is one of my samples.

Through our dynamic analysis by running the test suites, we find that 2 of the runtime dependencies are installed, however, they are not used during test runtime. We removed these dependencies from package.json, and installed the remaining dependencies, the tests all passed.

Would you consider creating a slim version of the package.json, which can help reduce the corresponding maintenance costs and security risks in production?

